### PR TITLE
only need dependency on hip::host

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,12 +65,10 @@ target_compile_definitions(librett PUBLIC ${LIBRETT_COMPILE_DEFS})
 if(ENABLE_CUDA)
   if (BUILD_SHARED_LIBS)
     target_link_libraries(librett PUBLIC CUDA::cudart)
-  else()
-    target_link_libraries(librett PUBLIC CUDA::cudart_static)
   endif()
 endif()
 if(ENABLE_HIP)
-  target_link_libraries(librett PUBLIC hip::device)
+  target_link_libraries(librett PUBLIC hip::host)
 endif()
 
 # Install


### PR DESCRIPTION
`hip::device` only needed in pre-3.21 cmake per https://rocm.docs.amd.com/en/latest/understand/cmake_packages.html#compiling-device-code-in-c-language-mode