### PR TITLE
Make CMake export include directories in target.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,9 @@ install(TARGETS librett
 
 set_target_properties(librett PROPERTIES EXPORT_NAME librett)
 
+# Export include directories. Fixes compatibility with FetchContent.
+target_include_directories(librett PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+
 #Install headers
 install(FILES ${LIBRETT_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/librett)
 


### PR DESCRIPTION
I was having trouble getting my code to find LibreTT headers. It looked like the include directories were not being added to the `librett::librett` target. This was the fix that I found was able to solve this. 