### PR TITLE
Update to compiler with OneAPI 2025

### DIFF
--- a/src/librett.cpp
+++ b/src/librett.cpp
@@ -402,7 +402,7 @@ sycl::vec<unsigned, 4> ballot(sycl::sub_group sg, bool predicate = true) __attri
   #ifdef __SYCL_DEVICE_ONLY__
     return __spirv_GroupNonUniformBallot(__spv::Scope::Subgroup, predicate);
   #else
-    throw sycl::exception(std::error_code(PI_ERROR_INVALID_DEVICE, sycl::sycl_category()), "Sub-groups are not supported on host device.");
+    throw sycl::exception(sycl::errc::runtime, "Sub-groups are not supported on host device.");
   #endif
 }
 #endif


### PR DESCRIPTION
PI_ERROR_INVALID_DEVICE is no longer defined in OneAPI 2025.  

See https://github.com/intel/llvm/pull/13283#issue-2225641737  