### PR TITLE
Add more error handling coverage

### DIFF
--- a/src/GpuUtils.h
+++ b/src/GpuUtils.h
@@ -35,6 +35,7 @@ static int warp_size = 64;  // AMD change
 //
 #ifdef LIBRETT_USES_SYCL
   #define cudaCheck(stmt) do { int err = stmt; } while (0)
+  #define generalCheck(stmt) cudaCheck(stmt)
 #elif LIBRETT_USES_HIP
   #define hipCheck(stmt) do {                                                       \
     hipError_t err = stmt;                                                          \
@@ -44,6 +45,7 @@ static int warp_size = 64;  // AMD change
       exit(1);                                                                      \
     }                                                                               \
   } while(0)
+  #define generalCheck(stmt) hipCheck(stmt)
 #elif LIBRETT_USES_CUDA
   #define cudaCheck(stmt) do {                                                      \
     cudaError_t err = stmt;                                                         \
@@ -53,6 +55,7 @@ static int warp_size = 64;  // AMD change
       exit(1);                                                                      \
     }                                                                               \
   } while(0)
+  #define generalCheck(stmt) cudaCheck(stmt)
 #endif
 
 #define librettCheck(stmt) do {                                                     \

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -711,8 +711,8 @@ int getNumActiveBlock(const int method, const int sizeofType, const LaunchConfig
     {
     #ifndef LIBRETT_USES_SYCL
       #define CALL0(TYPE, NREG) \
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock, \
-          transposePacked<TYPE, NREG>, numthread, lc.shmemsize)
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock, \
+          transposePacked<TYPE, NREG>, numthread, lc.shmemsize))
       switch(lc.numRegStorage) {
         #define CALL(ICASE) case ICASE: if (sizeofType == 4) CALL0(float,  ICASE); \
 	                                if (sizeofType == 8) CALL0(double, ICASE); \
@@ -757,8 +757,8 @@ int getNumActiveBlock(const int method, const int sizeofType, const LaunchConfig
         // key not found in cache, determine value and add it to cache
         #ifndef LIBRETT_USES_SYCL
           #define CALL0(TYPE, NREG) \
-            gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock, \
-              transposePackedSplit<TYPE, NREG>, numthread, lc.shmemsize)
+            generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock, \
+              transposePackedSplit<TYPE, NREG>, numthread, lc.shmemsize))
           switch(lc.numRegStorage) {
             #define CALL(ICASE) case ICASE: if (sizeofType == 4) CALL0(float,  ICASE); \
 		                            if (sizeofType == 8) CALL0(double, ICASE); \
@@ -777,15 +777,15 @@ int getNumActiveBlock(const int method, const int sizeofType, const LaunchConfig
     {
     #ifndef LIBRETT_USES_SYCL
       if (sizeofType == 4) {
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
-          transposeTiled<float>, numthread, lc.shmemsize);
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
+          transposeTiled<float>, numthread, lc.shmemsize));
       } else if (sizeofType == 8) {
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
-          transposeTiled<double>, numthread, lc.shmemsize);
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
+          transposeTiled<double>, numthread, lc.shmemsize));
       }
       else if (sizeofType == 16) {
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
-          transposeTiled<librett_complex>, numthread, lc.shmemsize);
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
+          transposeTiled<librett_complex>, numthread, lc.shmemsize));
       }
     #endif // CUDA or HIP
     }
@@ -795,14 +795,14 @@ int getNumActiveBlock(const int method, const int sizeofType, const LaunchConfig
     {
     #ifndef LIBRETT_USES_SYCL
       if (sizeofType == 4) {
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
-          transposeTiledCopy<float>, numthread, lc.shmemsize);
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
+          transposeTiledCopy<float>, numthread, lc.shmemsize));
       } else if (sizeofType == 8) {
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
-          transposeTiledCopy<double>, numthread, lc.shmemsize);
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
+          transposeTiledCopy<double>, numthread, lc.shmemsize));
       } else if (sizeofType == 16) {
-        gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
-          transposeTiledCopy<librett_complex>, numthread, lc.shmemsize);
+        generalCheck(gpuOccupancyMaxActiveBlocksPerMultiprocessor(&numActiveBlock,
+          transposeTiledCopy<librett_complex>, numthread, lc.shmemsize));
       }
     #endif // CUDA or HIP
     }

--- a/tests/librett_bench.cpp
+++ b/tests/librett_bench.cpp
@@ -154,14 +154,14 @@ int main(int argc, char *argv[])
 
   gpuStream = new sycl::queue(sycl::gpu_selector_v, Librett::sycl_asynchandler, sycl::property_list{sycl::property::queue::in_order{}});
 #elif LIBRETT_USES_HIP
-  hipStreamCreate(&gpuStream);
+  hipCheck(hipStreamCreate(&gpuStream));
   if (elemsize == 4) {
     hipCheck(hipDeviceSetSharedMemConfig(hipSharedMemBankSizeFourByte));
   } else {
     hipCheck(hipDeviceSetSharedMemConfig(hipSharedMemBankSizeEightByte));
   }
 #elif LIBRETT_USES_CUDA
-  cudaStreamCreate(&gpuStream);
+  cudaCheck(cudaStreamCreate(&gpuStream));
   if (elemsize == 4) {
     cudaCheck(cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte));
   } else {


### PR DESCRIPTION
Several return status codes are ignored. This throws multiple warnings for every instance, making it very difficult to figure out where a build is failing. This code fixes it.